### PR TITLE
GitHub action for building narya in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,12 @@ on:
   push:
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    - uses: actions/checkout@v4
+    - uses: DeterminateSystems/nix-installer-action@main
+    - run: nix profile install nixpkgs#cachix
+    - run: env CACHIX_AUTH_TOKEN=${{ secrets.CACHIX_AUTH_TOKEN }} cachix watch-exec narya -- nix develop --accept-flake-config . --command dune test
   build:
     runs-on: ubuntu-latest
     steps:
@@ -12,4 +18,3 @@ jobs:
     - uses: DeterminateSystems/nix-installer-action@main
     - run: nix profile install nixpkgs#cachix
     - run: env CACHIX_AUTH_TOKEN=${{ secrets.CACHIX_AUTH_TOKEN }} cachix watch-exec narya -- nix build --accept-flake-config .
-    - run: env CACHIX_AUTH_TOKEN=${{ secrets.CACHIX_AUTH_TOKEN }} cachix watch-exec narya -- nix develop --accept-flake-config

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,15 @@
+name: "Build"
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: DeterminateSystems/nix-installer-action@main
+    - run: nix profile install nixpkgs#cachix
+    - run: env CACHIX_AUTH_TOKEN=${{ secrets.CACHIX_AUTH_TOKEN }} cachix watch-exec narya -- nix build --accept-flake-config .
+    - run: env CACHIX_AUTH_TOKEN=${{ secrets.CACHIX_AUTH_TOKEN }} cachix watch-exec narya -- nix develop --accept-flake-config


### PR DESCRIPTION
This adds a github action for building a static version of narya in CI. It also uploads the build and its dependencies to a cache, so that local builds of narya/future CI builds of narya can simply pull dependencies from cache.

What it should also do is upload the static narya binary somewhere; that is a TODO.