### PR TITLE
Nonparametricity is inherited by definitions

### DIFF
--- a/bin/narya.ml
+++ b/bin/narya.ml
@@ -15,7 +15,7 @@ let usage_msg = "narya [options] <file1> [<file2> ...]"
 let interactive = ref false
 let proofgeneral = ref false
 
-(* Undocumented flag used for testing: interpret a given command-line string as if it were entered in interactive mode. *)
+(* Undocumented flag used for testing: interpret a given file or command-line string as if it were entered in interactive mode. *)
 let fake_interacts : string Bwd.t ref = ref Emp
 
 let speclist =
@@ -212,7 +212,10 @@ let () =
     (* Note: run_top executes the input files, so here we only have to do the interaction. *)
     Mbwd.miter
       (fun [ file ] ->
-        let p, src = Parser.Command.Parse.start_parse (`File file) in
+        let source : Asai.Range.source =
+          if FileUtil.test Is_file file then `File file
+          else `String { title = Some "command line fake-interact"; content = file } in
+        let p, src = Parser.Command.Parse.start_parse source in
         Reporter.try_with ~emit:(Reporter.display ~output:stdout)
           ~fatal:(Reporter.display ~output:stdout) (fun () -> Execute.batch None p src `None []))
       [ !fake_interacts ];

--- a/docs/source/parametric-observational-type-theory.rst
+++ b/docs/source/parametric-observational-type-theory.rst
@@ -239,8 +239,8 @@ Similarly, when defining a codatatype lying in a higher universe, the "self" var
 
    def Gel (A B : Type) (R : A → B → Type) : Id Type A B ≔ codata [ x .ungel : R x.0 x.1 ]
 
-Varying the behavior of parametricity
--------------------------------------
+Varying the arity of parametricity
+----------------------------------
 
 The parametricity described above, which is Narya's default, is *binary* in that the identity/bridge type ``Id A x y`` takes *two* elements of ``A`` as arguments.  However, a different "arity" can be specified with the ``-arity`` command-line flag.  For instance, under ``-arity 1`` we have bridge types ``Id A x``, and under ``-arity 3`` they look like ``Id A x y z``.  Everything else also alters according, e.g. under ``-arity 1`` the type ``Id (A → B) f`` is isomorphic to ``(x : A) (x' : Id A x) → Id B (f x)``, and a cube variable has pieces numbered with only ``0`` s and ``1`` s.
 
@@ -250,9 +250,16 @@ It is also possible to rename or remove the primitives ``refl`` and ``Id`` (whic
 
 The name of ``sym`` cannot be changed or removed, and likewise for the digits used in generic degeneracies to indicate permuted dimensions.
 
-Finally, parametricity can be set to be *internal* (the default) or *external*.  Setting it to external instead means that dimension-changing degeneracies (including ``refl``, but not ``sym``) can only be applied to *closed terms*.  Since degeneracies also compute fully on closed terms (at least in the "up-to-definitional-isomorphism" sense), we can then more or less think of these operations as meta-operations on syntax rather than intrinsic aspects of the theory.  This is the usual meaning of "external parametricity", although Narya's is of course at least partially internalized.  (Semantically, what Narya calls "external parametricity" is modeled in a diagram of *semi-cubical* types, in contrast to internal parametricity which is modeled in *cubical* types.)
+Internal versus external parametricity
+--------------------------------------
 
-In addition, under external parametricity, *axioms* are not permitted to be used inside of dimension-changing degeneracies either.  The reasoning behind this is that we may want to assume axioms that are inconsistent with parametricity, such as excluded middle, while still making use of external parametricity on other types.  (Note that *internal* parametricity is nonclassical, actively contradicting excluded middle.)  It also maintains the principle that assuming an axiom of type `A` is equivalent to working in a context extended by a variable of type `A`.  However, in the future it may be possible to declare a special kind of "parametric axiom" that does have higher-dimensional versions.
+Parametricity can also be set to be *internal* or *external* with the like-named flags ``-internal`` and ``-external``.  Internal is the default and the behavior that we have described up until now.  Setting it to external instead means that dimension-changing degeneracies (such as ``refl``, but not ``sym``) can only be applied to *closed terms*.  Since degeneracies also compute fully on closed terms (at least in the "up-to-definitional-isomorphism" sense), we can then more or less think of these operations as meta-operations on syntax rather than intrinsic aspects of the theory.  This is the usual meaning of "external parametricity", although Narya's is of course at least partially internalized.  (Semantically, what Narya calls "external parametricity" is modeled in a diagram of *semi-cubical* types, in contrast to internal parametricity which is modeled in *cubical* types.)
+
+In addition, when parametricity is external, *axioms* are not permitted to be used inside of dimension-changing degeneracies either, nor are any constants that use axioms in their types or definitions, hereditarily.  That is, axioms are "nonparametric" and have no dimension-changing degeneracies, and any definition that uses a nonparametric constant is also nonparametric.  Similarly, if any of the definitions in a mutual block use a nonparametric constant, then all the constants in the mutual block are nonparametric.
+
+The reasoning behind this is that you may want to assume axioms that are inconsistent with parametricity, such as excluded middle, while still making use of external parametricity on other types.  (Note that *internal* parametricity is nonclassical, actively contradicting excluded middle.)  It also maintains the principle that assuming an axiom of type `A` is equivalent to working in a context extended by a variable of type `A`.  However, in the future it may be possible to declare a special kind of "parametric axiom" that does have higher-dimensional versions.
+
+When a definition contains :ref:`holes` but does not (yet) use any nonparametric constants, it is considered parametric, and hence can have dimension-changing degeneracies applied to it.  Therefore, if you later try to fill one of those holes with a term that uses a nonparametric constant, an error will be emitted; it is not possible to retroactively set a definition to be nonparametric since it might already have had dimension-changing degeneracies applied to it by other definitions.  In this case, you have to undo back to the original definition and manually copy your desired nonparametric term in place of the hole.  (If there is significant demand, we may implement an easier solution.)
 
 The combination ``-arity 1 -direction d -external`` is a version of `displayed type theory <https://arxiv.org/abs/2311.18781>`_ (dTT), and as such can be selected with the single option ``-dtt``.  The primary differences between ``narya -dtt`` and the original dTT of the paper are:
 

--- a/lib/core/command.ml
+++ b/lib/core/command.ml
@@ -72,7 +72,7 @@ let check_term (def : defined_const) (discrete : unit Constant.Map.t option) :
           (check ?discrete
              (Potential (Constant (const, D.zero), Ctx.apps ctx, Ctx.lam ctx))
              ctx tm ety) in
-      Global.set const (Defined tm);
+      Global.set const (`Defined tm, `Maybe_parametric);
       (const, tm)
   | Defined_synth { const; params; tm } ->
       let Checked_tel (cparams, ctx), _ = check_tel Ctx.empty params in
@@ -81,7 +81,7 @@ let check_term (def : defined_const) (discrete : unit Constant.Map.t option) :
       let cty = readback_val ctx ety in
       let ty = Telescope.pis cparams cty in
       let tm = Ctx.lam ctx ctm in
-      Global.add const ty (Defined tm);
+      Global.add const ty (`Defined tm, `Maybe_parametric);
       (const, tm)
 
 (* Iterate through a collection of such things checking them all, and then verify whether they are all potentially-discrete datatypes.  If so, redefine them all to be actually discrete (`Yes instead of `Maybe).  Returns a list of constant names to print, and whether they are discrete. *)
@@ -99,14 +99,14 @@ let check_terms (defs : defined_const list) (discrete : unit Constant.Map.t opti
               let discrete_def, disc_def = Discrete.discrete_def def in
               ((c, discrete_def), disc && disc_def))
             [ defineds ] true in
-        if disc then
-          ( Bwd_extra.to_list_map
-              (fun (c, def) ->
-                Global.set c (Defined def);
-                PConstant c)
-              discrete_defineds,
-            true )
-        else (Bwd_extra.to_list_map (fun (c, _) -> PConstant c) defineds, false)
+        let parametric =
+          (Global.get_parametric () :> [ `Parametric | `Nonparametric | `Maybe_parametric ]) in
+        ( Bwd_extra.to_list_map
+            (fun (c, def) ->
+              Global.set c (`Defined def, parametric);
+              PConstant c)
+            (if disc then discrete_defineds else defineds),
+          disc )
     | d :: defs ->
         let c, v = check_term d discrete in
         go defs (Snoc (defineds, (c, v))) in
@@ -122,8 +122,8 @@ let check_defs (defs : (Constant.t * defconst) list) : printable list * bool =
         let Checked_tel (params, ctx), disc = check_tel ?discrete Ctx.empty params in
         let ty = check (Kinetic `Nolet) ctx ty (universe D.zero) in
         let pi_cty = Telescope.pis params ty in
-        (* We set the type now; the value will be added later. *)
-        Global.add const pi_cty (Axiom `Parametric);
+        (* We set the type now; the value will be added later.  We mark it as "maybe parametric" so that we can detect if it is used behind an external degeneracy. *)
+        Global.add const pi_cty (`Axiom, `Maybe_parametric);
         go defs
           (if disc then Option.map (Constant.Map.add const ()) discrete else None)
           (Snoc (defineds, Defined_check { const; bplus; params; ty; tm }))
@@ -134,12 +134,14 @@ let check_defs (defs : (Constant.t * defconst) list) : printable list * bool =
 
 let execute : t -> unit = function
   | Axiom (const, params, ty) ->
+      Global.set_nonparametric None;
       let Checked_tel (params, ctx), _ = check_tel Ctx.empty params in
       let cty = check (Kinetic `Nolet) ctx ty (universe D.zero) in
       let cty = Telescope.pis params cty in
-      Global.add const cty (Axiom `Nonparametric);
+      Global.add const cty (`Axiom, `Nonparametric);
       Global.end_command (fun h -> Constant_assumed (PConstant const, h))
   | Def defs ->
+      Global.set_maybe_parametric ();
       let printables, discrete = check_defs defs in
       Global.end_command (fun h -> Constant_defined (printables, discrete, h))
   | Solve (global, status, termctx, tm, ty, callback) ->

--- a/lib/core/global.mli
+++ b/lib/core/global.mli
@@ -3,7 +3,10 @@ open Util
 open Tbwd
 open Term
 
-type definition = Axiom of [ `Parametric | `Nonparametric ] | Defined of (emp, potential) term
+type definition =
+  [ `Axiom | `Defined of (emp, potential) term ]
+  * [ `Parametric | `Nonparametric | `Maybe_parametric ]
+
 type metamap
 
 val find : Constant.t -> (emp, kinetic) term * definition
@@ -46,7 +49,10 @@ val add_hole :
   unit
 
 val hole_exists : ('a, 'b, 's) Meta.t -> bool
-val with_definition : Constant.t -> definition -> (unit -> 'a) -> 'a
+
+val with_definition :
+  Constant.t -> [ `Axiom | `Defined of (emp, potential) term ] -> (unit -> 'a) -> 'a
+
 val with_meta_definition : ('a, 'b, 's) Meta.t -> ('b, 's) term -> (unit -> 'x) -> 'x
 val without_definition : Constant.t -> Reporter.Code.t -> (unit -> 'a) -> 'a
 val without_meta_definition : ('a, 'b, 's) Meta.t -> Reporter.Code.t -> (unit -> 'x) -> 'x
@@ -70,6 +76,7 @@ type eternity = {
     No.interval option ->
     No.interval option ->
     unit;
+  modify : 'a 'b 's. ('a, 'b, 's) Meta.t -> (data -> data) -> unit;
 }
 
 val eternity : eternity ref
@@ -80,5 +87,9 @@ end
 
 module HolePos : module type of State.Make (HoleState)
 
+val set_nonparametric : Constant.t option -> unit
+val set_parametric : Constant.t -> unit
+val set_maybe_parametric : unit -> unit
+val get_parametric : unit -> [ `Parametric | `Nonparametric ]
 val end_command : (int -> Reporter.Code.t) -> unit
 val run_command_with : init:data -> (int -> Reporter.Code.t) -> (unit -> 'a) -> 'a

--- a/lib/core/norm.ml
+++ b/lib/core/norm.ml
@@ -125,7 +125,7 @@ and eval : type m b s. (m, b) env -> (b, s) term -> s evaluation =
                 })) in
       let head = Const { name; ins = ins_zero dim } in
       match defn with
-      | Defined tree -> (
+      | `Defined tree, _ -> (
           if GluedEval.read () then
             (* Glued evaluation: we evaluate the definition lazily and return a neutral with that lazy evaluation stored. *)
             Val (Neu { head; args = Emp; value = lazy_eval (Emp dim) tree; ty })
@@ -139,7 +139,7 @@ and eval : type m b s. (m, b) env -> (b, s) term -> s evaluation =
                   d.tyfam := Some (lazy { tm = newtm; ty = Lazy.force ty });
                 Val newtm
             | _ -> Val newtm)
-      | Axiom _ -> Val (Neu { head; args = Emp; value = ready Unrealized; ty }))
+      | `Axiom, _ -> Val (Neu { head; args = Emp; value = ready Unrealized; ty }))
   | Meta (meta, ambient) -> (
       let dim = dim_env env in
       let head = Value.Meta { meta; env; ins = ins_zero dim } in

--- a/lib/core/reporter.ml
+++ b/lib/core/reporter.ml
@@ -165,7 +165,8 @@ module Code = struct
     | Invalid_constructor_type : Constr.t -> t
     | Missing_constructor_type : Constr.t -> t
     | Locked_variable : t
-    | Locked_axiom : printable -> t
+    | Locked_constant : printable -> t
+    | Axiom_in_parametric_definition : printable -> t
     | Hole : string * printable -> t
     | No_open_holes : t
     | Open_holes : int -> t
@@ -305,7 +306,8 @@ module Code = struct
     | Invalid_constructor_type _ -> Error
     | Missing_constructor_type _ -> Error
     | Locked_variable -> Error
-    | Locked_axiom _ -> Error
+    | Locked_constant _ -> Error
+    | Axiom_in_parametric_definition _ -> Error
     | Hole _ -> Info
     | No_open_holes -> Info
     | Open_holes _ -> Warning
@@ -378,7 +380,8 @@ module Code = struct
     | Undefined_metavariable _ -> "E0302"
     | Ill_scoped_connection -> "E0303"
     | Locked_variable -> "E0310"
-    | Locked_axiom _ -> "E0311"
+    | Locked_constant _ -> "E0311"
+    | Axiom_in_parametric_definition _ -> "E0312"
     (* Bidirectional typechecking and case trees *)
     | Nonsynthesizing _ -> "E0400"
     | Unequal_synthesized_type _ -> "E0401"
@@ -802,8 +805,13 @@ module Code = struct
             (Constr.to_string c)
       | Missing_constructor_type c ->
           textf "missing type for constructor %s of indexed datatype" (Constr.to_string c)
-      | Locked_variable -> text "variable locked behind external degeneracy"
-      | Locked_axiom a -> textf "axiom %a locked behind external degeneracy" pp_printed (print a)
+      | Locked_variable -> text "variable not available inside external degeneracy"
+      | Locked_constant a ->
+          textf "constant %a uses nonparametric axioms, can't appear inside an external degeneracy"
+            pp_printed (print a)
+      | Axiom_in_parametric_definition a ->
+          textf "constant %a uses nonparametric axioms, can't be used in a parametric definition"
+            pp_printed (print a)
       | Hole (n, ty) -> textf "@[<v 0>hole %s:@,%a@]" n pp_printed (print ty)
       | No_open_holes -> text "no open holes"
       | Open_holes n ->

--- a/lib/parser/eternity.ml
+++ b/lib/parser/eternity.ml
@@ -70,6 +70,16 @@ let () =
                     }
                     map;
               }));
+      modify =
+        (fun (type a b s) m f ->
+          S.modify (fun { map } ->
+              {
+                map =
+                  Metamap.update m
+                    (Option.map (fun (md : (unit, a, b, s) MetaData.t) ->
+                         { md with homewhen = { md.homewhen with global = f md.homewhen.global } }))
+                    map;
+              }));
     }
 
 let unsolved () =

--- a/lib/parser/pi.ml
+++ b/lib/parser/pi.ml
@@ -22,5 +22,5 @@ let install trie =
       (Parse.Term.parse (`String { content = "A B |-> (x : A) -> B x"; title = None })) in
   let rtm = process Emp ptm in
   let ctm = check (Potential (Constant (const, D.zero), Ctx.apps ctx, Ctx.lam ctx)) ctx rtm ety in
-  Global.add const cty (Defined ctm);
+  Global.add const cty (`Defined ctm, `Parametric);
   Scope.Mod.union_singleton ~prefix:Emp trie ([ "Π" ], ((`Constant const, None), ()))

--- a/test/black/dtt.t/mutual.ny
+++ b/test/black/dtt.t/mutual.ny
@@ -1,4 +1,0 @@
-{` We check that a family of mutual definitions can apply external degeneracies to each other.  This was an issue once because they are temporarily defined as "axioms" during definition, and by default axioms don't admit external degeneracies. `}
-def X : Type ≔ Type
-
-and Y : (x : X) → X⁽ᵈ⁾ x ≔ ?

--- a/test/black/dtt.t/run.t
+++ b/test/black/dtt.t/run.t
@@ -182,7 +182,7 @@ Or of anything that uses an axiom.
    ￮ axiom A assumed
   
    ￫ info[I0000]
-   ￮ constant f defined
+   ￮ nonparametric constant f defined
   
    ￫ error[E0311]
    ￭ command-line exec string
@@ -217,7 +217,7 @@ But if one of them uses an axiom, the others don't have external degeneracies ei
    ￮ axiom A assumed
   
    ￫ info[I0000]
-   ￮ constants defined mutually:
+   ￮ nonparametric constants defined mutually:
        f
        g
   

--- a/test/black/dtt.t/run.t
+++ b/test/black/dtt.t/run.t
@@ -158,20 +158,96 @@
    ￫ error[E0310]
    ￭ command-line exec string
    1 | def foo (X:Type) : Type^^(d) X := X^^(d)
-     ^ variable locked behind external degeneracy
+     ^ variable not available inside external degeneracy
   
   [1]
 
-  $ narya -dtt -e "axiom A : Type" -e "echo A^^(d)"
+Can't take external degeneracies of axioms.
+
+  $ narya -dtt -v -e "axiom A : Type" -e "echo A⁽ᵈ⁾"
+   ￫ info[I0001]
+   ￮ axiom A assumed
+  
    ￫ error[E0311]
    ￭ command-line exec string
-   1 | echo A^^(d)
-     ^ axiom A locked behind external degeneracy
+   1 | echo A⁽ᵈ⁾
+     ^ constant A uses nonparametric axioms, can't appear inside an external degeneracy
   
   [1]
 
-  $ narya -dtt mutual.ny
-   ￫ error[E3002]
-   ￮ file mutual.ny contains open holes
+Or of anything that uses an axiom.
+
+  $ narya -dtt -v -e "axiom A : Type def f : A → A ≔ x ↦ x echo f⁽ᵈ⁾"
+   ￫ info[I0001]
+   ￮ axiom A assumed
+  
+   ￫ info[I0000]
+   ￮ constant f defined
+  
+   ￫ error[E0311]
+   ￭ command-line exec string
+   1 | axiom A : Type def f : A → A ≔ x ↦ x echo f⁽ᵈ⁾
+     ^ constant f uses nonparametric axioms, can't appear inside an external degeneracy
   
   [1]
+
+We check that a family of mutual definitions can apply external degeneracies to each other.  This was an issue once because they are temporarily defined as "axioms" during definition, and by default axioms don't admit external degeneracies.
+
+  $ narya -dtt -v -e "def X : Type ≔ Type and Y : (x : X) → X⁽ᵈ⁾ x ≔ ?"
+   ￫ info[I0000]
+   ￮ constants defined mutually, containing 1 hole:
+       X
+       Y
+  
+   ￫ info[I3003]
+   ￮ hole ?0:
+     
+     ----------------------------------------------------------------------
+     (x : Type) → Type⁽ᵈ⁾ x
+  
+   ￫ error[E3002]
+   ￮ command-line exec string contains open holes
+  
+  [1]
+
+But if one of them uses an axiom, the others don't have external degeneracies either.
+
+  $ narya -dtt -v -e "axiom A:Type def f : Type := A and g : Type := sig () echo g⁽ᵈ⁾"
+   ￫ info[I0001]
+   ￮ axiom A assumed
+  
+   ￫ info[I0000]
+   ￮ constants defined mutually:
+       f
+       g
+  
+   ￫ error[E0311]
+   ￭ command-line exec string
+   1 | axiom A:Type def f : Type := A and g : Type := sig () echo g⁽ᵈ⁾
+     ^ constant g uses nonparametric axioms, can't appear inside an external degeneracy
+  
+  [1]
+
+When a constant is defined containing a hole, it is allowed to be parametric, but then the hole cannot be filled by any term that uses an axiom.
+
+  $ narya -dtt -v -fake-interact "axiom A:Type def B:Type := ? echo B⁽ᵈ⁾ solve 0 := A"
+   ￫ info[I0001]
+   ￮ axiom A assumed
+  
+   ￫ info[I0000]
+   ￮ constant B defined, containing 1 hole
+  
+   ￫ info[I3003]
+   ￮ hole ?0:
+     
+     ----------------------------------------------------------------------
+     Type
+  
+  B⁽ᵈ⁾
+    : Type⁽ᵈ⁾ B
+  
+   ￫ error[E0312]
+   ￭ command line fake-interact
+   1 | axiom A:Type def B:Type := ? echo B⁽ᵈ⁾ solve 0 := A
+     ^ constant A uses nonparametric axioms, can't be used in a parametric definition
+  

--- a/test/black/dtt.t/sst.ny
+++ b/test/black/dtt.t/sst.ny
@@ -1,81 +1,92 @@
 {` Unary Gel-types `}
-def Gel (A : Type) (A' : A → Type) : Type⁽ᵈ⁾ A ≔ sig x ↦ (ungel : A' x)
+def Gel (A : Type) (A' : A → Type) : Type⁽ᵈ⁾ A ≔ sig x ↦ ( ungel : A' x )
 
 {` The definition of semi-simplicial types `}
-def SST : Type ≔ codata [
-| X .z : Type
-| X .s : (X .z) → SST⁽ᵈ⁾ X
-]
+def SST : Type ≔ codata [ X .z : Type | X .s : (X .z) → SST⁽ᵈ⁾ X ]
 
 ` Extracting some low-dimensional simplices
 def 0s (X : SST) : Type ≔ X .z
 
 def 1s (X : SST) (x₀ x₁ : 0s X) : Type ≔ X .s x₀ .z x₁
 
-def 2s (X : SST) (x₀ x₁ : 0s X) (x₀₁ : 1s X x₀ x₁) (x₂ : 0s X) (x₀₂ : 1s X x₀ x₂) (x₁₂ : 1s X x₁ x₂) : Type
+def 2s (X : SST) (x₀ x₁ : 0s X) (x₀₁ : 1s X x₀ x₁) (x₂ : 0s X)
+  (x₀₂ : 1s X x₀ x₂) (x₁₂ : 1s X x₁ x₂)
+  : Type
   ≔ X .s x₀ .s x₁ x₀₁ .z x₂ x₀₂ x₁₂
 
-def 3s (X : SST) (x₀ x₁ : 0s X) (x₀₁ : 1s X x₀ x₁) (x₂ : 0s X) (x₀₂ : 1s X x₀ x₂) (x₁₂ : 1s X x₁ x₂) (x₀₁₂ : 2s X x₀ x₁ x₀₁ x₂ x₀₂ x₁₂)
-  (x₃ : 0s X) (x₀₃ : 1s X x₀ x₃) (x₁₃ : 1s X x₁ x₃) (x₀₁₃ : 2s X x₀ x₁ x₀₁ x₃ x₀₃ x₁₃)
-  (x₂₃ : 1s X x₂ x₃) (x₀₂₃ : 2s X x₀ x₂ x₀₂ x₃ x₀₃ x₂₃) (x₁₂₃ : 2s X x₁ x₂ x₁₂ x₃ x₁₃ x₂₃)
+def 3s (X : SST) (x₀ x₁ : 0s X) (x₀₁ : 1s X x₀ x₁) (x₂ : 0s X)
+  (x₀₂ : 1s X x₀ x₂) (x₁₂ : 1s X x₁ x₂) (x₀₁₂ : 2s X x₀ x₁ x₀₁ x₂ x₀₂ x₁₂)
+  (x₃ : 0s X) (x₀₃ : 1s X x₀ x₃) (x₁₃ : 1s X x₁ x₃)
+  (x₀₁₃ : 2s X x₀ x₁ x₀₁ x₃ x₀₃ x₁₃) (x₂₃ : 1s X x₂ x₃)
+  (x₀₂₃ : 2s X x₀ x₂ x₀₂ x₃ x₀₃ x₂₃) (x₁₂₃ : 2s X x₁ x₂ x₁₂ x₃ x₁₃ x₂₃)
   : Type
   ≔ X .s x₀ .s x₁ x₀₁ .s x₂ x₀₂ x₁₂ x₀₁₂ .z x₃ x₀₃ x₁₃ x₀₁₃ x₂₃ x₀₂₃ x₁₂₃
 
 {` Singular SSTs, based on the Martin-Lof jdentity type for now. `}
-def eq (A:Type) (x:A) : A → Type ≔ data [ rfl. : eq A x x ]
+def eq (A : Type) (x : A) : A → Type ≔ data [ rfl. : eq A x x ]
 
 def Sing (A : Type) : SST ≔ [
 | .z ↦ A
-| .s ↦ x ↦ Sing⁽ᵈ⁾ A (Gel A (y ↦ eq A x y))
-]
+| .s ↦ x ↦ Sing⁽ᵈ⁾ A (Gel A (y ↦ eq A x y))]
 
 {` We normalize some low-dimensional simplex types of singular SSTs. `}
 axiom A : Type
+
 echo 0s (Sing A)
 
 axiom a₀ : 0s (Sing A)
+
 axiom a₁ : 0s (Sing A)
+
 echo 1s (Sing A) a₀ a₁
 
 axiom a₀₁ : 1s (Sing A) a₀ a₁
+
 axiom a₂ : 0s (Sing A)
+
 axiom a₀₂ : 1s (Sing A) a₀ a₂
+
 axiom a₁₂ : 1s (Sing A) a₁ a₂
+
 echo 2s (Sing A) a₀ a₁ a₀₁ a₂ a₀₂ a₁₂
 
 axiom a₀₁₂ : 2s (Sing A) a₀ a₁ a₀₁ a₂ a₀₂ a₁₂
+
 axiom a₃ : 0s (Sing A)
+
 axiom a₀₃ : 1s (Sing A) a₀ a₃
+
 axiom a₁₃ : 1s (Sing A) a₁ a₃
+
 axiom a₀₁₃ : 2s (Sing A) a₀ a₁ a₀₁ a₃ a₀₃ a₁₃
+
 axiom a₂₃ : 1s (Sing A) a₂ a₃
+
 axiom a₀₂₃ : 2s (Sing A) a₀ a₂ a₀₂ a₃ a₀₃ a₂₃
+
 axiom a₁₂₃ : 2s (Sing A) a₁ a₂ a₁₂ a₃ a₁₃ a₂₃
+
 echo 3s (Sing A) a₀ a₁ a₀₁ a₂ a₀₂ a₁₂ a₀₁₂ a₃ a₀₃ a₁₃ a₀₁₃ a₂₃ a₀₂₃ a₁₂₃
 
 {` The empty SST `}
-def sst.∅ : SST ≔ [
-| .z ↦ data [ ]
-| .s ↦ [ ]
-]
+def sst.∅ : SST ≔ [ .z ↦ data [] | .s ↦ [ ] ]
 
 {` The unit SST `}
-def sst.𝟙 : SST ≔ [
-| .z ↦ sig ()
-| .s ↦ _ ↦ sst.𝟙⁽ᵈ⁾
-]
+def sst.𝟙 : SST ≔ [ .z ↦ sig () | .s ↦ _ ↦ sst.𝟙⁽ᵈ⁾ ]
 
 {` Binary products of SSTs `}
 def sst.prod (X Y : SST) : SST ≔ [
-| .z ↦ sig ( fst : X .z, snd : Y .z )
-| .s ↦ xy ↦ sst.prod⁽ᵈ⁾ X (X .s (xy .fst)) Y (Y .s (xy .snd))
-]
+| .z ↦ sig (
+    fst : X .z,
+    snd : Y .z )
+| .s ↦ xy ↦ sst.prod⁽ᵈ⁾ X (X .s (xy .fst)) Y (Y .s (xy .snd))]
 
 {` Dependent Σ-SSTs require symmetry! `}
 def sst.Σ (X : SST) (Y : SST⁽ᵈ⁾ X) : SST ≔ [
-| .z ↦ sig ( fst : X .z, snd : Y .z fst )
-| .s ↦ xy ↦ sst.Σ⁽ᵈ⁾ X (X .s (xy .fst)) Y (sym (Y .s (xy .fst) (xy .snd)))
-]
+| .z ↦ sig (
+    fst : X .z,
+    snd : Y .z fst )
+| .s ↦ xy ↦ sst.Σ⁽ᵈ⁾ X (X .s (xy .fst)) Y (sym (Y .s (xy .fst) (xy .snd)))]
 
 {`
 We can check this by hand too:
@@ -96,84 +107,83 @@ So the type of "Y .s⁽ᵈ⁾ (xy .fst) (xy .snd)" is indeed symmetrized from wh
 
 {` Constant displayed SSTs also require symmetry, as noted in the paper. `}
 def sst.const (X Y : SST) : SST⁽ᵈ⁾ X ≔ [
-| .z ↦ sig _ ↦ ( ungel : Y .z )
-| .s ↦ x y ↦ sym (sst.const⁽ᵈ⁾ X (X .s x) Y (Y .s (y .ungel)))
-]
+| .z ↦ sig _ ↦ (
+    ungel : Y .z )
+| .s ↦ x y ↦ sym (sst.const⁽ᵈ⁾ X (X .s x) Y (Y .s (y .ungel)))]
 
 {` Using constant displayed SSTs, we can define binary sum SSTs. `}
 def sst.sum (X Y : SST) : SST ≔ [
-| .z ↦ data [ inl. (_ : X .z) | inr. (_ : Y .z) ]
+| .z ↦ data [
+  | inl. (_ : X .z)
+  | inr. (_ : Y .z) ]
 | .s ↦ [
   | inl. x ↦ sst.sum⁽ᵈ⁾ X (X .s x) Y (sst.const Y sst.∅)
-  | inr. y ↦ sst.sum⁽ᵈ⁾ X (sst.const X sst.∅) Y (Y .s y)
-  ]
-]
+  | inr. y ↦ sst.sum⁽ᵈ⁾ X (sst.const X sst.∅) Y (Y .s y)]]
 
 {` Augmented SSTs are another displayed coinductive. `}
-def ASST : Type ≔ codata [
-| X .z : Type
-| X .s : ASST⁽ᵈ⁾ X
-]
+def ASST : Type ≔ codata [ X .z : Type | X .s : ASST⁽ᵈ⁾ X ]
 
 {` As is pointedness of an SST. `}
 def sst.pt (X : SST) : Type ≔ codata [
 | p .z : X .z
-| p .s : sst.pt⁽ᵈ⁾ X (X .s (p .z)) p
-]
+| p .s : sst.pt⁽ᵈ⁾ X (X .s (p .z)) p ]
 
 {` And maps of SSTs. `}
 def sst.hom (X Y : SST) : Type ≔ codata [
 | f .z : X .z → Y .z
-| f .s : (x : X .z) → sst.hom⁽ᵈ⁾ X (X .s x) Y (Y .s (f .z x)) f
-]
+| f .s : (x : X .z) → sst.hom⁽ᵈ⁾ X (X .s x) Y (Y .s (f .z x)) f ]
 
 {` Identities and composition for maps `}
 def sst.id (X : SST) : sst.hom X X ≔ [
 | .z ↦ x ↦ x
-| .s ↦ x ↦ sst.id⁽ᵈ⁾ X (X .s x)
-]
+| .s ↦ x ↦ sst.id⁽ᵈ⁾ X (X .s x)]
 
-def sst.comp (X Y Z : SST) (g : sst.hom Y Z) (f : sst.hom X Y) : sst.hom X Z ≔ [
+def sst.comp (X Y Z : SST) (g : sst.hom Y Z) (f : sst.hom X Y) : sst.hom X Z
+  ≔ [
 | .z ↦ x ↦ g .z (f .z x)
-| .s ↦ x ↦ sst.comp⁽ᵈ⁾ X (X .s x) Y (Y .s (f .z x)) Z (Z .s (g .z (f .z x))) g (g .s (f .z x)) f (f .s x)
-]
+| .s ↦ x ↦
+    sst.comp⁽ᵈ⁾ X (X .s x) Y (Y .s (f .z x)) Z (Z .s (g .z (f .z x))) g
+      (g .s (f .z x)) f (f .s x)]
 
 {` Universal maps `}
-def sst.abort (X : SST) : sst.hom sst.∅ X ≔ [
-| .z ↦ [ ]
-| .s ↦ [ ]
-]
+def sst.abort (X : SST) : sst.hom sst.∅ X ≔ [ .z ↦ [ ] | .s ↦ [ ] ]
 
 def sst.uniq (X : SST) : sst.hom X sst.𝟙 ≔ [
 | .z ↦ _ ↦ ()
-| .s ↦ x ↦ sst.uniq⁽ᵈ⁾ X (X .s x)
-]
+| .s ↦ x ↦ sst.uniq⁽ᵈ⁾ X (X .s x)]
 
-def sst.pair (X Y Z : SST) (f : sst.hom X Y) (g : sst.hom X Z) : sst.hom X (sst.prod Y Z) ≔ [
+def sst.pair (X Y Z : SST) (f : sst.hom X Y) (g : sst.hom X Z)
+  : sst.hom X (sst.prod Y Z)
+  ≔ [
 | .z ↦ x ↦ (f .z x, g .z x)
-| .s ↦ x ↦ sst.pair⁽ᵈ⁾ X (X .s x) Y (Y .s (f .z x)) Z (Z .s (g .z x)) f (f .s x) g (g .s x)
-]
+| .s ↦ x ↦
+    sst.pair⁽ᵈ⁾ X (X .s x) Y (Y .s (f .z x)) Z (Z .s (g .z x)) f (f .s x) g
+      (g .s x)]
 
 {` Copairing requires a displayed version of abort.  And for that, we can't match directly against (x' .ungel) since it isn't a variable, so we have to define a helper function first. `}
 def sst.abortz (X : Type) : sst.∅ .z → X ≔ [ ]
 
-def sst.const_abort (X Y : SST) (Y' : SST⁽ᵈ⁾ Y) (f : sst.hom X Y) : sst.hom⁽ᵈ⁾ X (sst.const X sst.∅) Y Y' f ≔ [
+def sst.const_abort (X Y : SST) (Y' : SST⁽ᵈ⁾ Y) (f : sst.hom X Y)
+  : sst.hom⁽ᵈ⁾ X (sst.const X sst.∅) Y Y' f
+  ≔ [
 | .z ↦ x x' ↦ sst.abortz (Y' .z (f .z x)) (x' .ungel)
-| .s ↦ x x' ↦ sst.abortz
-  {` Ideally, this big long argument should be obtainable by unification. `}
-	(sst.hom⁽ᵈᵈ⁾
-    X (sst.const X sst.∅) (X .s x) (sym (sst.const⁽ᵈ⁾ X (X .s x) sst.∅ (sst.∅ .s (x' .ungel))))
-    Y Y' (Y .s (f .z x)) (Y' .s (f .z x) (sst.abortz (Y' .z (f .z x)) (x' .ungel)))
-    f (sst.const_abort X Y Y' f) (f .s x))
-  (x' .ungel)
-]
+| .s ↦ x x' ↦
+    sst.abortz
+      {` Ideally, this big long argument should be obtainable by unification. `}
+      (sst.hom⁽ᵈᵈ⁾ X (sst.const X sst.∅) (X .s x)
+         (sym (sst.const⁽ᵈ⁾ X (X .s x) sst.∅ (sst.∅ .s (x' .ungel)))) Y Y'
+         (Y .s (f .z x))
+         (Y' .s (f .z x) (sst.abortz (Y' .z (f .z x)) (x' .ungel))) f
+         (sst.const_abort X Y Y' f) (f .s x)) (x' .ungel)]
 
-def sst.copair (X Y Z : SST) (f : sst.hom X Z) (g : sst.hom Y Z) : sst.hom (sst.sum X Y) Z ≔ [
+def sst.copair (X Y Z : SST) (f : sst.hom X Z) (g : sst.hom Y Z)
+  : sst.hom (sst.sum X Y) Z
+  ≔ [
 | .z ↦ [ inl. x ↦ f .z x | inr. y ↦ g .z y ]
 | .s ↦ [
-  | inl. x ↦ sst.copair⁽ᵈ⁾ X (X .s x) Y (sst.const Y sst.∅) Z (Z .s (f .z x))
-                f (f .s x) g (sst.const_abort Y Z (Z .s (f .z x)) g)
-  | inr. y ↦ sst.copair⁽ᵈ⁾ X (sst.const X sst.∅) Y (Y .s y) Z (Z .s (g .z y))
-                f (sst.const_abort X Z (Z .s (g .z y)) f) g (g .s y)
-  ]
-]
+  | inl. x ↦
+      sst.copair⁽ᵈ⁾ X (X .s x) Y (sst.const Y sst.∅) Z (Z .s (f .z x)) f
+        (f .s x) g (sst.const_abort Y Z (Z .s (f .z x)) g)
+  | inr. y ↦
+      sst.copair⁽ᵈ⁾ X (sst.const X sst.∅) Y (Y .s y) Z (Z .s (g .z y)) f
+        (sst.const_abort X Z (Z .s (g .z y)) f) g (g .s y)]]

--- a/test/testutil/repl.ml
+++ b/test/testutil/repl.ml
@@ -39,7 +39,7 @@ let assume (name : string) (ty : string) : unit =
       @@ fun () ->
       let rty = parse_term ty in
       let cty = check_type rty in
-      Global.add const cty (Axiom `Nonparametric)
+      Global.add const cty (`Axiom, `Nonparametric)
   | _ -> fatal (Invalid_constant_name [ name ])
 
 let def (name : string) (ty : string) (tm : string) : unit =
@@ -59,9 +59,9 @@ let def (name : string) (ty : string) (tm : string) : unit =
       let cty = check_type rty in
       let ety = eval_term (Emp D.zero) cty in
       Reporter.trace "when checking case tree" @@ fun () ->
-      Global.add const cty (Axiom `Parametric);
+      Global.add const cty (`Axiom, `Parametric);
       let tree = check (Potential (Constant (const, D.zero), Emp, fun x -> x)) Ctx.empty rtm ety in
-      Global.add const cty (Defined tree)
+      Global.add const cty (`Defined tree, `Parametric)
   | _ -> fatal (Invalid_constant_name [ name ])
 
 let equal_at (tm1 : string) (tm2 : string) (ty : string) : unit =

--- a/test/white/constants.ml
+++ b/test/white/constants.ml
@@ -33,7 +33,7 @@ let () =
   equal_at "ab .0" "a" "A";
   equal_at "ab .1" "b" "B a";
   (match Global.find (Option.get (Parser.Scope.lookup [ "ab" ])) with
-  | _, Defined _ -> ()
+  | _, (`Defined _, _) -> ()
   | _ -> raise (Failure "pair wasn't defined to be a tree"));
   def "zero_zero'" "Σ CN (_ ↦ CN)" "( fst ≔ zero , snd ≔ zero )";
   equal_at "zero_zero" "zero_zero'" "Σ CN (_ ↦ CN)";


### PR DESCRIPTION
Under `-external` (including `-dtt`), axioms are not supposed to be allowed inside dimension-changing degeneracies.  But the following used to work:
```
axiom A : Type
def f : A → A ≔ x ↦ x
echo f⁽ᵈ⁾
```
which obviously doesn't make sense.  This PR fixes that, so that nonparametricity is inherited by definitions that use axioms or other nonparametric definitions.