### PR TITLE
Update flake inputs to latest versions

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -70,11 +70,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744232761,
-        "narHash": "sha256-gbl9hE39nQRpZaLjhWKmEu5ejtQsgI5TWYrIVVJn30U=",
+        "lastModified": 1748370509,
+        "narHash": "sha256-QlL8slIgc16W5UaI3w7xHQEP+Qmv/6vSNTpoZrrSlbk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f675531bc7e6657c10a18b565cfebd8aa9e24c14",
+        "rev": "4faa5f5321320e49a78ae7848582f684d64783e9",
         "type": "github"
       },
       "original": {
@@ -99,11 +99,11 @@
         "opam2json": "opam2json"
       },
       "locked": {
-        "lastModified": 1744377764,
-        "narHash": "sha256-CKZLqLgZtMrUyZKlroISYp6Z4aoN1N9xeyk0dPNxGvc=",
+        "lastModified": 1747738995,
+        "narHash": "sha256-dpZ4SA6+wKywKN1YgWhcJZ7UqCmjwEuUlA2d1m6ELQ4=",
         "owner": "tweag",
         "repo": "opam-nix",
-        "rev": "33a339b3a871eecfcb0ad3222366e6d8ce4bff6a",
+        "rev": "b6b3f218745dd74ddacac39c789e1d0cb0c68150",
         "type": "github"
       },
       "original": {
@@ -131,11 +131,11 @@
     "opam-repository": {
       "flake": false,
       "locked": {
-        "lastModified": 1744388127,
-        "narHash": "sha256-EgMUWmpHJEzwtN19Atho+OaF6KuhvrdR+oLTrpdF5hI=",
+        "lastModified": 1748528847,
+        "narHash": "sha256-o+rLpi7gvkRZfkYe+cq+1FzyNQmnUm3zBl/S7Sll030=",
         "owner": "ocaml",
         "repo": "opam-repository",
-        "rev": "34a3fc46c301a891122df75c17fef6b5358bd68f",
+        "rev": "fe6c88ce9c55ea8b8a6de550613ec7c5ff502c1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
While following the instructions given in the documentation for **Compiling with nix**, I got the same error message referenced in #70. Running the command `nix flake update` that updates the file `flake.lock` helped me to solve the issue.