### PR TITLE
require OCaml 5.3

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,5 +1,6 @@
 profile = default
 version = 0.27.0
+ocaml-version = 5.3
 margin=100
 break-before-in=auto
 break-infix=fit-or-vertical

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -78,7 +78,7 @@ The static binary does not work on a Mac, but you can compile Narya from source 
 Compiling from source
 ---------------------
 
-If the static binary does not work for you (such as if you are on MacOS), or if you want to edit the Narya code, you will have to compile it yourself.  This requires a recent version of OCaml and various libraries.  Currently Narya is developed with OCaml 5.3.0; as far as I know, it also compiles with any version after 5.2.1, but this is not regularly verified.  You can set up a :ref:`Manual development environment` or look into :ref:`Compiling with nix`.
+If the static binary does not work for you (such as if you are on MacOS), or if you want to edit the Narya code, you will have to compile it yourself.  This requires a recent version of OCaml and various libraries.  Narya requires OCaml 5.3.0 or later.  You can set up a :ref:`Manual development environment` or look into :ref:`Compiling with nix`.
 
 
 Manual development environment

--- a/lib/util/query.ml
+++ b/lib/util/query.ml
@@ -11,14 +11,7 @@ struct
 
   let run ~(ask : Q.question -> Q.answer) f =
     let open Effect.Deep in
-    try_with f ()
-      {
-        effc =
-          (fun (type a) (eff : a Effect.t) ->
-            match eff with
-            | Ask q -> Option.some @@ fun (k : (a, _) continuation) -> continue k (ask q)
-            | _ -> None);
-      }
+    try f () with effect Ask q, k -> continue k (ask q)
 
   let register_printer f =
     Printexc.register_printer @@ function

--- a/lib/util/state.ml
+++ b/lib/util/state.ml
@@ -12,33 +12,19 @@ struct
   let run ~(init : State.t) f =
     let open Effect.Deep in
     let st = ref init in
-    try_with f ()
-      {
-        effc =
-          (fun (type a) (eff : a Effect.t) ->
-            match eff with
-            | Get -> Option.some @@ fun (k : (a, _) continuation) -> continue k !st
-            | Set v ->
-                Option.some @@ fun (k : (a, _) continuation) ->
-                st := v;
-                continue k ()
-            | _ -> None);
-      }
+    try f () with
+    | effect Get, k -> continue k !st
+    | effect Set v, k ->
+        st := v;
+        continue k ()
 
   let try_with ?(get = get) ?(set = set) f =
     let open Effect.Deep in
-    try_with f ()
-      {
-        effc =
-          (fun (type a) (eff : a Effect.t) ->
-            match eff with
-            | Get -> Option.some @@ fun (k : (a, _) continuation) -> continue k (get ())
-            | Set v ->
-                Option.some @@ fun (k : (a, _) continuation) ->
-                set v;
-                continue k ()
-            | _ -> None);
-      }
+    try f () with
+    | effect Get, k -> continue k (get ())
+    | effect Set v, k ->
+        set v;
+        continue k ()
 
   let modify f = set @@ f @@ get ()
 


### PR DESCRIPTION
Now that OCaml 5.4 is almost out, it's probably okay to require OCaml 5.3.  The main thing this gives us is a pleasant syntax for effect handlers.